### PR TITLE
CANVAS-102 - Bruincast script duplicates records

### DIFF
--- a/src/client/components/AdminPanel/BruincastListingsTable.js
+++ b/src/client/components/AdminPanel/BruincastListingsTable.js
@@ -51,7 +51,7 @@ export const BruincastListingsTable = ({ shortname, listings }) => {
         {listings.map(listing => (
           <Table.Row key={listing.filename}>
             <Table.Cell>{listing.term}</Table.Cell>
-            <Table.Cell>{listing.classID}</Table.Cell>
+            <Table.Cell>{listing.srs}</Table.Cell>
             <Table.Cell>{listing.week}</Table.Cell>
             <Table.Cell>{listing.date}</Table.Cell>
             <Table.Cell>

--- a/src/server/jobs/update-bcast.js
+++ b/src/server/jobs/update-bcast.js
@@ -170,7 +170,7 @@ async function main() {
             );
             if (weekNum === null) {
               logger.log({
-                level: 'warning',
+                level: 'warn',
                 message: `Null response from getWeekNumber for ${mediaEntry['date for recording(s)']}`,
               });
             }

--- a/src/server/jobs/update-bcast.js
+++ b/src/server/jobs/update-bcast.js
@@ -145,18 +145,18 @@ async function main() {
 
       // For each term and Class ID, get the associated media and update records
       for await (const course of courses) {
-        const currentClassID = course['srs #'];
+        const currentSRS = course['srs #'];
         const currentClassShortname = await registrar.getShortname(
           currentTerm,
-          currentClassID
+          currentSRS
         );
         logger.info(
-          `Updating records for ${currentClassShortname} (Class ID: ${currentClassID})`
+          `Updating records for ${currentClassShortname} (Class ID: ${currentSRS})`
         );
         let numCourseRecords = 0;
 
         // From the API, get media listings for given term and Class ID
-        await getMedia(formattedTerm, currentClassID, async function(
+        await getMedia(formattedTerm, currentSRS, async function(
           mediaResponse
         ) {
           const mediaEntries = JSON.parse(mediaResponse);
@@ -177,7 +177,7 @@ async function main() {
 
             mediaRecords.push({
               classShortname: currentClassShortname,
-              classID: currentClassID,
+              srs: currentSRS,
               term: currentTerm,
               date: mediaEntry['date for recording(s)'],
               week: weekNum,
@@ -195,7 +195,7 @@ async function main() {
             client,
             'bruincastmedia',
             currentTerm,
-            currentClassID,
+            currentSRS,
             mediaRecords,
             logger
           );


### PR DESCRIPTION
Fixed duplication bug by using `srs` field consistently across all records. "Class ID" is still displayed in the UI though, consistent with the Registrar's updated terminology.