### PR TITLE
CANVAS-125 - Incorrect shortnames being generated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "simple-react-full-stack",
+  "name": "lti-media-resources",
   "version": "1.0.0",
-  "description": "Boilerplate to build a full stack web application using React, Node.js, Express and Webpack.",
+  "description": "",
   "main": "src/server/index.js",
   "scripts": {
     "build": "webpack --mode production",
@@ -11,10 +11,11 @@
     "dev": "migrate-mongo up && concurrently \"npm run server\" \"npm run client\"",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "jest"
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
-  "author": "Sandeep Raveesh",
-  "license": "ISC",
+  "author": "UC Regents",
+  "license": "BSD-2",
   "dependencies": {
     "@babel/runtime": "^7.10.5",
     "@instructure/canvas-high-contrast-theme": "^7.1.1",

--- a/src/server/jobs/update-videores.js
+++ b/src/server/jobs/update-videores.js
@@ -54,7 +54,7 @@ async function main() {
           logger.warn(`${media.term}-${media.srs} does not have shortname`);
         } else if (!media.filename.includes(shortname)) {
           logger.warn(
-            `Shortname of file ${media.filename} does not match the shortname of class ${media.srs} of term ${media.term}`
+            `Shortname of file ${media.filename} does not match the shortname ${shortname} (${media.term}|${media.srs})`
           );
         }
         media.classShortname = shortname;

--- a/src/server/services/registrar.js
+++ b/src/server/services/registrar.js
@@ -2,9 +2,9 @@ const axios = require('axios');
 const https = require('https');
 const fs = require('fs');
 const registrarDebug = require('debug')('registrar:api');
-require('dotenv').config();
-
 const cache = require('./cache');
+
+require('dotenv').config();
 
 let registrar = {};
 
@@ -186,22 +186,33 @@ async function getShortname(offeredTermCode, classSectionID) {
         registrarDebug('getShortname: Classes is null');
         return returnObject;
       }
-      const {
-        classes: [
-          {
-            termSessionGroupCollection: [
-              { termsessionGroupCode: sessionGroup },
-            ],
-          },
-        ],
-      } = response;
+
+      // Find the session that matches the class number.
+      let sessionGroup = '';
+      response.classes[0].termSessionGroupCollection.forEach(groupItem => {
+        groupItem.classCollection.forEach(classItem => {
+          if (classItem.classNumber === secNum) {
+            sessionGroup = groupItem.termsessionGroupCode;
+          }
+        });
+      });
+
+      registrarDebug(`getShortname: using sessionGroup ${sessionGroup}`);
       term += sessionGroup;
     }
 
-    const shortname = `${term}-${subArea.replace(/\s|&/g, '')}${catNum.replace(
-      /\s|^0+/g,
+    // Format catNum from 0000SSPP to PP . int(0000) . SS.
+    // SS are section letters. PP is C(oncurrent) and/or M(ultilisted).
+    const formattedCatNum =
+      catNum.substr(6, 2).trim() +
+      parseInt(catNum.substr(0, 4)) +
+      catNum.substr(4, 2).trim();
+
+    // Remove spaces and ampersands.
+    const shortname = `${term}-${subArea.replace(
+      /\s|&/g,
       ''
-    )}-${secNum.replace(/^0+/g, '')}`;
+    )}${formattedCatNum}-${secNum.replace(/^0+/g, '')}`;
 
     registrarDebug(`getShortname: returning { ${shortname}, ${subArea}`);
     returnObject.shortname = shortname;

--- a/src/server/services/tests/registrar.getShortname.test.js
+++ b/src/server/services/tests/registrar.getShortname.test.js
@@ -45,10 +45,11 @@ it('returns complex shortname', async () => {
   });
 
   const { shortname } = await registrar.getShortname('20S', '370705200');
-  expect(shortname).toEqual('20S-CSBIO150M-1');
+  expect(shortname).toEqual('20S-CSBIOM150-1');
 });
 
 it('returns summer shortnames', async () => {
+  // Just one summer section.
   registrar.call = jest
     .fn()
     .mockImplementationOnce(() => ({
@@ -75,6 +76,7 @@ it('returns summer shortnames', async () => {
             {
               termsessionGroupCode: 'A',
               termsessionInstructionWeeks: '8',
+              classCollection: [{ classNumber: '001' }],
             },
           ],
         },
@@ -87,6 +89,7 @@ it('returns summer shortnames', async () => {
   );
   expect(shortnameA).toEqual('201A-COMSCI31-1');
 
+  // Multiple summer sessions.
   registrar.call = jest
     .fn()
     .mockImplementationOnce(() => ({
@@ -96,8 +99,8 @@ it('returns summer shortnames', async () => {
             {
               subjectAreaCode: 'LIFESCI',
               courseCatalogNumber: '0030B',
-              classNumber: '001',
-              classSectionNumber: '001',
+              classNumber: '002',
+              classSectionNumber: '002',
             },
           ],
         },
@@ -108,8 +111,14 @@ it('returns summer shortnames', async () => {
         {
           termSessionGroupCollection: [
             {
+              termsessionGroupCode: 'A',
+              termsessionInstructionWeeks: '8',
+              classCollection: [{ classNumber: '001' }],
+            },
+            {
               termsessionGroupCode: 'C',
               termsessionInstructionWeeks: '6',
+              classCollection: [{ classNumber: '002' }],
             },
           ],
         },
@@ -120,5 +129,5 @@ it('returns summer shortnames', async () => {
     '201',
     '252091930'
   );
-  expect(shortnameC).toEqual('201C-LIFESCI30B-1');
+  expect(shortnameC).toEqual('201C-LIFESCI30B-2');
 });


### PR DESCRIPTION
Some issues with the getShortname method.

1. The CM [C(oncurrent) or M(ultilisted)] letter is prefixing the course number. e.g. 20S-CSBIO150M-1 instead of 20S-CSBIOM150-1
2. For summer sessions, if a course is offered in both session A and C, only the first session code is every added.

