### PR TITLE
CANVAS-165 - dockerize app to run on AWS ECS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+node_modules
+dist
+*.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 node_modules
 dist
 *.log
+deploy.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@
 node_modules
 dist
 *.log
-deploy.sh

--- a/.env.dist
+++ b/.env.dist
@@ -7,6 +7,9 @@ DB_DATABASE=lti-media-resources
 DB_MAX_POOL_SIZE=25
 DB_MAX_IDLE_TIME_MS=60000
 
+# AWS Credentials
+AWS_ACCOUNT_ID=
+
 # LTI config
 LTI_KEY=YOURKEY
 PLATFORM_URL=http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ dist
 .env
 .DS_Store
 # Server certificates and keys
+nginx-conf/certs
 src/server/locals/*.cer
 src/server/locals/*.key

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:erbium
+FROM node:14-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -7,4 +7,7 @@ COPY . /usr/src/app
 
 EXPOSE 8080
 
-CMD ["yarn", "start"]
+RUN yarn install
+RUN yarn build
+
+CMD ["node", "/usr/src/app/src/server/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:erbium
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+
+EXPOSE 8080
+
+CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:erbium
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -7,7 +7,4 @@ COPY . /usr/src/app
 
 EXPOSE 8080
 
-RUN yarn install
-RUN yarn build
-
-CMD ["node", "/usr/src/app/src/server/index.js"]
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Once the task is running, you can now connect it to the CCLE LTI tool.
 2. Under Network, copy and paste the Public IP
 3. Go to the External Tool Configuration on CCLE
 4. Copy and paste the IP with the port for Tool URL, Initiate login URL, and Redirection URI(s)
-   - It will be of the form `http://<Public IP>`
+   - It will be of the form `https://<Public IP>`
 5. To avoid CORS issues, switch Default launch container to New Window
 6. Save changes
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Make sure "Oregon" (us-west-2) is the selected region in the AWS Console before 
 4. Click on the "View push commands" button to view the 4 commands to push images to the repository
 5. After pushing an image to the repo, move on
 
+This will need to be repeated for each service listed in the Docker Compose file (Nodeserver and Nginx).
+
 ### Creating AWS ECS Cluster
 
 1. Go to AWS ECS (Elastic Container Service)
@@ -171,10 +173,11 @@ Make sure "Oregon" (us-west-2) is the selected region in the AWS Console before 
 3. Choose Fargate
 4. Enter a name, memory, and CPU size
 5. Click on Add Container
-6. Enter the information for the correct Docker image created earlier in the ECR
-   - the image name can be found in the repository (Image URI)
-7. Enter port 8080 for the Port mappings
-8. Create task definition
+   1. Add the container for the nodeserver (Image URI can be found in the ECR)
+      - Enter port 8080 for the Port Mappings
+   2. Add the container for the nginx server (Image URI can be found in the ECR)
+      - Enter port 80 for the Port Mappings
+6. Create task definition
 
 ### Creating ECS Service
 
@@ -188,9 +191,6 @@ Using the new task definition, we can now run the app on our cluster.
 6. Enter a service name
 7. Enter 1 for number of tasks
 8. Choose the first option for Cluster VPC and Subnets
-9. For Security Group, hit the edit button
-   - Add a rule for "All TCP"
-   - This will allow our container to receive traffic over port 8080.
 
 The service should now be running.
 
@@ -202,7 +202,7 @@ Once the task is running, you can now connect it to the CCLE LTI tool.
 2. Under Network, copy and paste the Public IP
 3. Go to the External Tool Configuration on CCLE
 4. Copy and paste the IP with the port for Tool URL, Initiate login URL, and Redirection URI(s)
-   - It will be of the form `http://<Public IP>:8080`
+   - It will be of the form `http://<Public IP>`
 5. To avoid CORS issues, switch Default launch container to New Window
 6. Save changes
 
@@ -210,9 +210,9 @@ Once the task is running, you can now connect it to the CCLE LTI tool.
 
 1. Push the new image to the repository (these can be found under "View push commands" in the AWS ECR repo)
    1. Retrieve login token - `aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin <AccountId>.dkr.ecr.us-west-2.amazonaws.com`
-   2. Build image - `docker build -t lti-media-resources .`
-   3. Tag image - `docker tag lti-media-resources:latest <AccountId>.dkr.ecr.us-west-2.amazonaws.com/lti-media-resources:latest`
-   4. Push image - `docker push <AccountId>.dkr.ecr.us-west-2.amazonaws.com/lti-media-resources:latest`
+   2. Build image - `docker-compose build`
+   3. Tag and Push Image - `docker-compose push`
+      - This will tag and push from the image field listed in the Docker Compose file
 2. Update the cluster service to use the new image - `aws ecs update-service --cluster <Cluster Name> --service <Service Name> --force-new-deployment`
 3. If Auto-Assign IP is on, the Public IP will be changed and need to be updated in the CCLE tool settings
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,6 @@ To create or modify the mongo migration script, see documentation at https://git
 
 ## Deploying to AWS
 
-### SSL Certificates
-
-The Nginx server and Dockerfile assume that the SSL public and private key are located in the `nginx-conf/certs` directory.
-
 ### Configure AWS CLI
 
 1. Download the CLI: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html
@@ -240,3 +236,15 @@ This can also be done manually in the AWS console if the new image has a differe
 7. Choose the latest revision for the task defintion
 
 The Service will now have the latest image of the app. The previous task will need to be stopped.
+
+### Deploying to Different Environments
+
+There are AWS ECS enviroments for PROD, STAGE, and TEST.
+
+Use the deploy script `./deploy.sh --id=<AWS_ACCOUNT_ID> --env=<PROD|STAGE|TEST>` to push the latest image to the respective environment.
+
+### SSL Certificates
+
+The Nginx server and Dockerfile assume that the SSL public and private keys for the different environments are located in the `nginx-conf/certs/<prod|stage|test>` directory.
+
+The file name for the keys should be `mediaresources-<ENV>.ccle.ucla.edu.cert.cer` and `mediaresources-<ENV>.ccle.ucla.edu.key` respectively.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ To create or modify the mongo migration script, see documentation at https://git
 
 ## Deploying to AWS
 
+### SSL Certificates
+
+The Nginx server and Dockerfile assume that the SSL public and private key are located in the `nginx-conf/certs` directory.
+
 ### Configure AWS CLI
 
 1. Download the CLI: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html

--- a/README.md
+++ b/README.md
@@ -240,3 +240,11 @@ This can also be done manually in the AWS console if the new image has a differe
 7. Choose the latest revision for the task defintion
 
 The Service will now have the latest image of the app. The previous task will need to be stopped.
+
+### Deploying to Different Environments
+
+There are AWS ECS enviroments for PROD, STAGE, and TEST.
+
+Use the deploy script `./deploy.sh --id=<AWS_ACCOUNT_ID> --env=<PROD|STAGE|TEST>` to push the latest image to the respective environment.
+
+NOTE: the DB_URL field in the .env must be commented out.

--- a/README.md
+++ b/README.md
@@ -208,14 +208,24 @@ Once the task is running, you can now connect it to the CCLE LTI tool.
 
 ### Updating ECS when deploying newer version of app
 
-1. Push the new image to the repository
-2. Click on the task definition
-3. Click on Create new revision
-4. Update the container defintion with the new image
-   - will not need to be changed if the image is tagged the same
-5. Update the task defintion revision
-6. Go to the ECS Cluster
-7. Click on the Service and hit Update
-8. Choose the latest revision for the task defintion
+1. Push the new image to the repository (these can be found under "View push commands" in the AWS ECR repo)
+   1. Retrieve login token - `aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin <AccountId>.dkr.ecr.us-west-2.amazonaws.com`
+   2. Build image - `docker build -t lti-media-resources .`
+   3. Tag image - `docker tag lti-media-resources:latest <AccountId>.dkr.ecr.us-west-2.amazonaws.com/lti-media-resources:latest`
+   4. Push image - `docker push <AccountId>.dkr.ecr.us-west-2.amazonaws.com/lti-media-resources:latest`
+2. Update the cluster service to use the new image - `aws ecs update-service --cluster <Cluster Name> --service <Service Name> --force-new-deployment`
+3. If Auto-Assign IP is on, the Public IP will be changed and need to be updated in the CCLE tool settings
+
+The Cluster will stop the old task once the newer version is up and running.
+
+This can also be done manually in the AWS console if the new image has a different tag.
+
+1. Click on the task definition
+2. Click on Create new revision
+3. Update the container defintion with the new image tag
+4. Update the task defintion revision
+5. Go to the ECS Cluster
+6. Click on the Service and hit Update
+7. Choose the latest revision for the task defintion
 
 The Service will now have the latest image of the app. The previous task will need to be stopped.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Make sure "Oregon" (us-west-2) is the selected region in the AWS Console before 
 
 This will need to be repeated for each service listed in the Docker Compose file (Nodeserver and Nginx).
 
+### Creating Network Load Balancer
+
+To utilize elastic IP with ECS Fargate, we need to use a NLB. Visit https://aws.amazon.com/premiumsupport/knowledge-center/ecs-fargate-static-elastic-ip-address/ for directions.
+
 ### Creating AWS ECS Cluster
 
 1. Go to AWS ECS (Elastic Container Service)
@@ -177,6 +181,7 @@ This will need to be repeated for each service listed in the Docker Compose file
       - Enter port 8080 for the Port Mappings
    2. Add the container for the nginx server (Image URI can be found in the ECR)
       - Enter port 80 for the Port Mappings
+      - Enter port 443 (SSL) for the Port Mappings
 6. Create task definition
 
 ### Creating ECS Service
@@ -191,6 +196,8 @@ Using the new task definition, we can now run the app on our cluster.
 6. Enter a service name
 7. Enter 1 for number of tasks
 8. Choose the first option for Cluster VPC and Subnets
+9. Edit the Security Group to allow traffic over HTTPS
+10. Select the Network Load Balancer
 
 The service should now be running.
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+usage() { echo "Usage: $0 --id=<AWS_ACCOUNT_ID> --env=<PROD|STAGE|TEST>" 1>&2; exit 1; }
+
+for i in "$@"
+do
+case $i in
+    --id=*)
+    AWS_ACCOUNT_ID="${i#*=}"
+    shift
+    ;;
+    --env=*)
+    ENV="${i#*=}"
+    if [[ ! $ENV =~ ^(PROD|STAGE|TEST)$ ]]; then
+      usage
+    fi
+    shift
+    ;;
+    *)
+      # unknown option
+      usage
+    ;;
+esac
+done
+aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
+docker-compose build
+docker-compose push
+if [[ $ENV == PROD ]]; then
+  echo "Deploying to PROD"
+  aws ecs update-service --cluster lti-cluster --service lti-media-resources-prod --force-new-deployment
+elif [[ $ENV == STAGE ]]; then
+  echo "Deploying to STAGE"
+  aws ecs update-service --cluster lti-cluster --service lti-media-resources-stage --force-new-deployment
+elif [[ $ENV == TEST ]]; then
+  echo "Deploying to TEST"
+  aws ecs update-service --cluster lti-cluster --service lti-media-resources-test --force-new-deployment
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,6 +22,9 @@ case $i in
     ;;
 esac
 done
+if [ -z "${AWS_ACCOUNT_ID}" ] || [ -z "${ENV}" ]; then
+  usage
+fi
 aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin ${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com
 docker-compose build
 docker-compose push

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  nodeserver:
+    image: '${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/lti-media-resources:latest'
+    build:
+      context: .
+    ports:
+      - '8080:8080'
+  nginx:
+    restart: always
+    image: '${AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/lti-nginx:latest'
+    build:
+      context: ./nginx-conf
+    ports:
+      - '80:80'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,3 @@ services:
       context: ./nginx-conf
     ports:
       - '80:80'
-      - '443:443'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,4 @@ services:
       context: ./nginx-conf
     ports:
       - '80:80'
+      - '443:443'

--- a/nginx-conf/Dockerfile
+++ b/nginx-conf/Dockerfile
@@ -1,2 +1,3 @@
 FROM nginx:1.18.0-alpine
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY certs /etc/nginx/certs

--- a/nginx-conf/Dockerfile
+++ b/nginx-conf/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:1.18.0-alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/nginx-conf/Dockerfile
+++ b/nginx-conf/Dockerfile
@@ -1,3 +1,2 @@
-FROM nginx:1.19.10-alpine
-COPY nginx.conf /etc/nginx/templates/default.conf.template
-COPY certs /etc/nginx/certs
+FROM nginx:1.18.0-alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/nginx-conf/Dockerfile
+++ b/nginx-conf/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:1.18.0-alpine
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+FROM nginx:1.19.10-alpine
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 COPY certs /etc/nginx/certs

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -1,0 +1,14 @@
+server {
+
+  listen 80;
+  server_name nodeserver;
+
+  location / {
+    proxy_pass http://localhost:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
+    proxy_cache_bypass $http_upgrade;
+  }
+}

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -1,28 +1,14 @@
 server {
-   listen 80;
-   server_name mediaresources.ccle.ucla.edu;
 
-   location / {
-      return 301 https://$host$request_uri;
-   }
-}
-
-server {
-
-  server_name ${NGINX_SERVER_NAME};
-
-  listen 443 ssl;
-  ssl_certificate /etc/nginx/certs/mediaresources_ccle_ucla_edu_cert.cer;
-  ssl_certificate_key /etc/nginx/certs/mediaresources.ccle.ucla.edu.key;
+  listen 80;
+  server_name nodeserver;
 
   location / {
+    proxy_pass http://localhost:8080;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'upgrade';
     proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-Proto https;
     proxy_cache_bypass $http_upgrade;
-
-    proxy_pass http://localhost:8080;
   }
 }

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -1,14 +1,28 @@
 server {
+   listen 80;
+   server_name mediaresources.ccle.ucla.edu;
 
-  listen 80;
-  server_name nodeserver;
+   location / {
+      return 301 https://$host$request_uri;
+   }
+}
+
+server {
+
+  server_name mediaresources.ccle.ucla.edu;
+
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/certs/mediaresources_ccle_ucla_edu_cert.cer;
+  ssl_certificate_key /etc/nginx/certs/mediaresources.ccle.ucla.edu.key;
 
   location / {
-    proxy_pass http://localhost:8080;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'upgrade';
     proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto https;
     proxy_cache_bypass $http_upgrade;
+
+    proxy_pass http://localhost:8080;
   }
 }

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -1,6 +1,6 @@
 server {
    listen 80;
-   server_name mediaresources.ccle.ucla.edu;
+   server_name ${NGINX_SERVER_NAME};
 
    location / {
       return 301 https://$host$request_uri;
@@ -12,8 +12,8 @@ server {
   server_name mediaresources.ccle.ucla.edu;
 
   listen 443 ssl;
-  ssl_certificate /etc/nginx/certs/mediaresources_ccle_ucla_edu_cert.cer;
-  ssl_certificate_key /etc/nginx/certs/mediaresources.ccle.ucla.edu.key;
+  ssl_certificate /etc/nginx/certs/${NGINX_ENV}/mediaresources-${NGINX_ENV}.ccle.ucla.edu.cert.cer;
+  ssl_certificate_key /etc/nginx/certs/${NGINX_ENV}/mediaresources-${NGINX_ENV}.ccle.ucla.edu.key;
 
   location / {
     proxy_http_version 1.1;

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -9,7 +9,7 @@ server {
 
 server {
 
-  server_name mediaresources.ccle.ucla.edu;
+  server_name ${NGINX_SERVER_NAME};
 
   listen 443 ssl;
   ssl_certificate /etc/nginx/certs/mediaresources_ccle_ucla_edu_cert.cer;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -24,6 +24,7 @@ options.loginRoute = `${approute}/login`;
 options.keysetRoute = `${approute}/keys`;
 options.invalidTokenRoute = `${approute}/invalidtoken`;
 options.sessionTimeoutRoute = `${approute}/sessiontimeout`;
+options.devMode = true;
 
 lti.setup(
   process.env.LTI_KEY,

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -24,7 +24,6 @@ options.loginRoute = `${approute}/login`;
 options.keysetRoute = `${approute}/keys`;
 options.invalidTokenRoute = `${approute}/invalidtoken`;
 options.sessionTimeoutRoute = `${approute}/sessiontimeout`;
-options.devMode = true;
 
 lti.setup(
   process.env.LTI_KEY,


### PR DESCRIPTION
Added dockerfile and documentation to run the app on AWS ECS. Dev mode is set to true to allow tokens to be sent over HTTP.