### PR TITLE
CANVAS-161 - migrate register calls to apigee

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -22,9 +22,7 @@ SERVERPORT=8080
 LTI_APPROUTE=
 
 # Registrar web services
-REG_WS_API_URL=https://webservicesqa.it.ucla.edu
-REG_WS_CERT_NAME=/replace/with/pathto/file.cer
-REG_WS_PRIVATE_KEY=/replace/with/pathto/file.key
+REG_WS_API_URL=https://api.ucla.edu
 SECRET_REG_WS_CLIENT_ID=
 SECRET_REG_WS_PASSWORD=
 

--- a/src/server/jobs/checkRegistrarWS.js
+++ b/src/server/jobs/checkRegistrarWS.js
@@ -5,7 +5,7 @@ const registrar = require('../services/registrar');
 // DEBUG='registrar:*' node src/server/jobs/checkRegistrarWS.js
 (async () => {
   const result = await registrar.call({
-    url: '/sis/api/v1/Infrastructure/VerifyConnectivity',
+    url: `/sis/infrastructure/verifyconnectivity/v1`,
     params: {
       anyText: new Date().toUTCString(),
     },


### PR DESCRIPTION
Migrate the register calls to apigee. 

To deal with retrying requests, I think we should install a package like https://www.npmjs.com/package/retry-axios and implement it in a separate PR.