### PR TITLE
CANVAS-107 - fix for themable jest warning

### DIFF
--- a/src/client/components/App/tests/App.test.js
+++ b/src/client/components/App/tests/App.test.js
@@ -7,6 +7,9 @@ import App from '../index';
 jest.mock('axios');
 jest.mock('../../../services/ltik');
 
+beforeEach(() => {
+  document.documentElement.setAttribute('dir', 'ltr');
+});
 afterEach(cleanup);
 
 test('Axios error handling in App', async (done) => {


### PR DESCRIPTION
Fixes "Warning: [themeable] component styles require setting a 'dir' attribute on the HTML element" while running Jest tests.